### PR TITLE
Add GitHub Actions configuration to build wheels with cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,6 +14,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, macos-13, macos-14]
@@ -24,6 +25,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
+          CIBW_SKIP: "*-i686 *-win32"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
-          CIBW_SKIP: "*-i686 *-win32"
+          CIBW_SKIP: "*_i686 *-win32"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,28 @@
+name: Wheels
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  build:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.17.0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
Add GitHub Actions CI workflow that builds the wheels using cibuildwheel. Currently it builds the wheels for Linux and macOS.

It follows https://cibuildwheel.pypa.io/en/stable/setup/#github-actions

Closes #1.