### PR TITLE
Bump build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
-    "setuptools>=63.4.1",
+    "setuptools >= 67",
     "wheel",
-    "numpy>=1.19.0",
-    "Cython",
+    "numpy >= 1.26",
+    "cython >= 3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -37,11 +37,11 @@ Code = "https://github.com/michelbierlaire/cythonbiogeme"
 
 [project.optional-dependencies]
 testing = [
-    "cython >= 0.29.32",
-    "numpy >= 1.23.4",
-    "pytest >= 7.2.0",
-    "pytest-cov >= 4.0.0",
-    "tox >= 3.27.1"
+    "cython >= 3",
+    "numpy >= 1.26",
+    "pytest >= 8",
+    "pytest-cov >= 5",
+    "tox >= 4"
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Bump the build requirements to the latest major stable version. Especially Cython 3 should help simplify stuff, and having a modern setuptools helps with using the latest `pyproject.toml` tricks.

The CI already uses the latest stable versions, but this ensure users also have a fairly modern version installed when installing cythonbiogeme.