### PR TITLE
CI: Add job that runs simple_test.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  test:
+    name: Run tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+      - name: Install dependencies
+        run: pip install .[testing]
+      - name: Run tests
+        run: pytest tests/simple_test.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,4 @@ testing = [
 ]
 
 [tool.setuptools.dynamic]
-version = { attr = "cythonbiogeme.version.__version__" }
+version = { attr = "cythonbiogeme.version.__version__", module = "src.cythonbiogeme" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,5 @@ testing = [
 ]
 
 [tool.setuptools.dynamic]
-version = { attr = "cythonbiogeme.version.__version__", module = "src.cythonbiogeme" }
+version = { attr = "cythonbiogeme.version.__version__", file = "src/cythonbiogeme/version.py" }
+


### PR DESCRIPTION
Adds a job that runs simple_test.py with pytest. This should make sure basic functionality, including import, works.