### PR TITLE
CI: Add job that runs simple_test.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  test:
+    name: Run tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+      - name: Install dependencies
+        run: pip install .[testing]
+      - name: Run tests
+        run: pytest tests/simple_test.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = [
     "numpy>=1.19.0",
     "Cython",
 ]
-build-backend = "setuptools.build_meta"
 
 [project]
 name = "cythonbiogeme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,9 @@ testing = [
     "tox >= 3.27.1"
 ]
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["cythonbiogeme"]
+
 [tool.setuptools.dynamic]
 version = { attr = "cythonbiogeme.version.__version__" }

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import platform
 
 def get_ext_modules():
     ext_modules = [
-        Extension(
-            "cythonbiogeme",
+        setuptools.Extension(
+            "cythonbiogeme.cythonbiogeme",
             sources=[
                 "src/cythonbiogeme/cpp/cythonbiogeme.pyx",
                 "src/cythonbiogeme/cpp/biogeme.cc",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import platform
 
 def get_ext_modules():
     ext_modules = [
-        setuptools.Extension(
+        Extension(
             "cythonbiogeme.cythonbiogeme",
             sources=[
                 "src/cythonbiogeme/cpp/cythonbiogeme.pyx",


### PR DESCRIPTION
Adds a job that runs simple_test.py with pytest. This should make sure basic functionality, including import, works.