### PR TITLE
CI: Fix config syntax, update cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
 	uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,13 +32,14 @@ jobs:
           pip install setuptools wheel numpy Cython
 
       - name: Install MSVC build tools for Windows
-	if: matrix.os == 'windows-latest'
-	uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
+          
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.python-version }}-${{ strategy.job-index }}


### PR DESCRIPTION
This PR does two things:
- Replaces some tabs by spaces, since the tabs break the CI config.
- Update cibuildwheel to the latest version, 2.19.2